### PR TITLE
Improved main focus logic. Animation effects needed.

### DIFF
--- a/src/css/greeting.css
+++ b/src/css/greeting.css
@@ -76,3 +76,4 @@
     margin-right: 5px;
     margin-left: 5px;
 }
+

--- a/src/css/todo.css
+++ b/src/css/todo.css
@@ -88,14 +88,14 @@ display: none;
 
 }
 
-.fa-trash-o {
+.fa-trash-o, .fa-plus {
 	color: red;
 	border: none;
 	font-size: 1.6em;
 	background: transparent;
 
 }
-.fa-trash-o::before{
+.fa-trash-o::before, .fa-plus::before{
     background: black;
     border: none;
 

--- a/src/js/greeting.js
+++ b/src/js/greeting.js
@@ -90,26 +90,84 @@ var Greeting = (function(){
 
 			mainTask.style.display = "inline-block";
 
-
-
-
-			
-
-			
+		
 	      
 	    }
 
 	}
 
-	function bindEditMainFocus(e){
+	//Main task event functions for mainTaskCheckbox mainTaskInput and mainTaskTrash
+	function bindCompletionEvent(e){
 
-		e.preventDefault();
+		 //on marking a todo as completed we should set its state and strikeout its description
 
-		var focusInput = document.getElementById("focusInput");
-		focusInput.classList.remove("focusEdited");
-		focusInput.setAttribute("readonly", false);
-		focusInput.addEventListener("keypress", bindMainFocus);
-		$("#editBtn").remove();
+    e.preventDefault();
+
+    //Get the next sibling of the checkbox to grab the input element
+    var displayTask = document.getElementById("mainTaskInput");
+    var taskDelBtn = document.getElementById("mainTaskTrash");
+    
+    if(e.target.checked){
+
+      //alert("Completion triggered");
+
+      displayTask.classList.add("completed");
+      mainTaskTrash.innerHTML = "<i class='fa fa-plus fa-2x' aria-hidden='true'></i>";
+
+    } else{
+
+      //alert("Uncompletion triggered");
+
+      displayTask.classList.remove("completed");
+      mainTaskTrash.innerHTML = "<i class='fa fa-trash-o' aria-hidden='true'></i>";
+    }
+
+    //Save main task state
+    
+
+	}
+
+	function bindMainTaskMouseEnter(e){
+
+		var taskCmpBtn = document.getElementById("mainTaskCheckbox");
+		taskCmpBtn.style.display = "inline";
+
+		var taskDelBtn = document.getElementById("mainTaskTrash");
+		taskDelBtn.style.display = "inline";
+
+	}
+
+	function bindMainTaskMouseExit(e){
+
+		var taskCmpBtn = document.getElementById("mainTaskCheckbox");
+
+		if(!taskCmpBtn.checked){
+
+		taskCmpBtn.style.display = "none";
+
+		var taskDelBtn = document.getElementById("mainTaskTrash");
+		taskDelBtn.style.display = "none";
+		}
+
+	}
+
+	function bindTaskRemovalEvent(e){
+
+		 e.preventDefault();
+
+	    //Get the next sibling of the checkbox to grab the input element
+	    //var displayTask = document.getElementById("mainTaskInput");
+
+	    //displayTask.style.display = "none";
+
+	    //displayTask.innerHTML = "";
+
+	    //Wipe the previous main task and re-render
+	    localStorage.removeItem("focus");
+
+	    DOM.$focus.html("");
+
+	    renderMainTask();
 
 	}
 
@@ -152,7 +210,7 @@ var Greeting = (function(){
 			DOM.$greeting.append(nameInput);
 		}else {
 
-			DOM.$greeting.html("Good " + tod + ", " + user);
+			DOM.$greeting.html("Good " + tod + ", " + user + ".");
 		}
 
 
@@ -198,7 +256,7 @@ var Greeting = (function(){
 			}else {
 
 				query.innerHTML ="Today";
-				DOM.$focus.append(query);
+				//DOM.$focus.append(query);
 
 				focusInput.style.display = "none";
 
@@ -223,11 +281,13 @@ var Greeting = (function(){
 	    taskCmpBtn.setAttribute("type", "checkbox");
 	    taskCmpBtn.setAttribute("id", mainCmpBtnId);
 	    taskCmpBtn.className = "taskCheckBox";
+	    taskCmpBtn.style.display = "none";
 	    //Check state of the task and marked checked if necessary
 	   /* if(this.completed){
 	      taskCmpBtn.checked = true;
 	    }*/
-	    //taskCmpBtn.addEventListener("change", bindCompletionEvent);
+	    taskCmpBtn.addEventListener("change", bindCompletionEvent);
+
 
 	    //Set up the task input and bind the edit event
 	    var mainInputId = "mainTaskInput";
@@ -239,6 +299,7 @@ var Greeting = (function(){
 	    //displayTask.setAttribute("readonly", "true");//displayTask.readOnly = true apparently you can only set this when the attribute is dropped in with setAttribute
 	    //displayTask.setAttribute("autocomplete", "off");
 	    displayTask.className = "taskDesc";
+	    
 	    //Check state of the task and strikeout text if necessary. Also conditionally bind edit event
 	   /* if(this.completed){
 	      displayTask.classList.add("completed");
@@ -254,11 +315,15 @@ var Greeting = (function(){
 	    taskDelBtn.setAttribute("id", mainDelBtnID);
 	    taskDelBtn.className = "taskTrash";
 	    taskDelBtn.innerHTML = "<i class='fa fa-trash-o' aria-hidden='true'></i>";
-	    //taskDelBtn.addEventListener("click", bindTaskRemovalEvent);
+	    taskDelBtn.addEventListener("click", bindTaskRemovalEvent);
+	    taskDelBtn.style.display = "none";
 
 	    mainTask.appendChild(taskCmpBtn);
 	    mainTask.appendChild(displayTask);
 	    mainTask.appendChild(taskDelBtn);
+
+	    mainTask.addEventListener("mouseenter", bindMainTaskMouseEnter);
+		mainTask.addEventListener("mouseleave", bindMainTaskMouseExit);
 	}
 
 	function renderTimeandDate() {


### PR DESCRIPTION
The main focus capture now works as expected. Users can enter their main focus, mark it complete and add another if they so desire. 

There's no prettiness to all of this so some focus will need to be given to applying the requisite effects to smooth the transition between visible states.

Note that since this is a part of the #middle element, it will still pop over panels (due to the z-index issue).